### PR TITLE
Fix expanding bottom sheet when not enough content

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,7 +26,6 @@
 	<style name="NoShapeBottomSheet" parent="Widget.MaterialComponents.BottomSheet.Modal">
 		<item name="shapeAppearance">@null</item>
 		<item name="shapeAppearanceOverlay">@null</item>
-		<item name="behavior_fitToContents">false</item>
 		<item name="android:background">@drawable/recipe_info_background</item>
 	</style>
 </resources>


### PR DESCRIPTION
This commit makes sure bottom sheet dialog has the size
of its contents. That way it doesn't expand further than it
should. Fixes #4