### PR TITLE
Fix background color for dark theme

### DIFF
--- a/app/src/main/res/drawable/recipe_info_background.xml
+++ b/app/src/main/res/drawable/recipe_info_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
 	android:shape="rectangle">
-	<solid android:color="@android:color/white" />
+	<solid android:color="?attr/colorOnPrimary" />
 	<corners
 		android:topLeftRadius="@dimen/rounded_corner_size_default"
 		android:topRightRadius="@dimen/rounded_corner_size_default" />


### PR DESCRIPTION
Hi, thank you for creating this app!
I noticed that with the dark theme activated on android there is no way to read the text because is white on white. 
This PR has a fix to this although I'm not sure if this is the best way to do it. Anyway is working now.

Thank you,
Cheers


![Screenshot_20211224-195937_Mealient](https://user-images.githubusercontent.com/29462014/147369860-025e562e-5e57-4852-a1f5-e6cb1eaa794b.png)

![Screenshot_20211224-200018_Mealient](https://user-images.githubusercontent.com/29462014/147369871-ca1db829-df82-403f-8a39-1898044775c9.png)