### PR TITLE
Fallback to HTTP if automatically chosen HTTPS fails

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,8 +16,8 @@ plugins {
 android {
     defaultConfig {
         applicationId = "gq.kirmanak.mealient"
-        versionCode = 25
-        versionName = "0.3.10"
+        versionCode = 26
+        versionName = "0.3.11"
         testInstrumentationRunner = "gq.kirmanak.mealient.MealientTestRunner"
         testInstrumentationRunnerArguments += mapOf("clearPackageData" to "true")
     }

--- a/app/src/main/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModel.kt
+++ b/app/src/main/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModel.kt
@@ -46,7 +46,7 @@ class BaseURLViewModel @Inject constructor(
         }
 
         val result: Result<Unit> = serverInfoRepo.tryBaseURL(url).recoverCatching {
-            logger.e(it) { "checkBaseURL: trying to recover" }
+            logger.e(it) { "checkBaseURL: trying to recover, had prefix = $hasPrefix" }
             if (hasPrefix.not() && it.cause is SSLHandshakeException) {
                 val unencryptedUrl = url.replace("https", "http")
                 serverInfoRepo.tryBaseURL(unencryptedUrl).getOrThrow()

--- a/app/src/main/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModel.kt
+++ b/app/src/main/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModel.kt
@@ -34,8 +34,8 @@ class BaseURLViewModel @Inject constructor(
     private suspend fun checkBaseURL(baseURL: String) {
         logger.v { "checkBaseURL() called with: baseURL = $baseURL" }
 
-        val hasPrefix = ALLOWED_PREFIXES.any { baseURL.startsWith(it) }
-        val urlWithPrefix = baseURL.takeIf { hasPrefix } ?: WITH_PREFIX_FORMAT.format(baseURL)
+        val hasPrefix = listOf("http://", "https://").any { baseURL.startsWith(it) }
+        val urlWithPrefix = baseURL.takeIf { hasPrefix } ?: "https://%s".format(baseURL)
         val url = urlWithPrefix.trimEnd { it == '/' }
 
         logger.d { "checkBaseURL: Created URL = \"$url\", with prefix = \"$urlWithPrefix\"" }
@@ -64,8 +64,4 @@ class BaseURLViewModel @Inject constructor(
         _uiState.value = OperationUiState.fromResult(result)
     }
 
-    companion object {
-        private val ALLOWED_PREFIXES = listOf("http://", "https://")
-        private const val WITH_PREFIX_FORMAT = "https://%s"
-    }
 }

--- a/app/src/main/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModel.kt
+++ b/app/src/main/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModel.kt
@@ -36,9 +36,9 @@ class BaseURLViewModel @Inject constructor(
 
         val hasPrefix = ALLOWED_PREFIXES.any { baseURL.startsWith(it) }
         val urlWithPrefix = baseURL.takeIf { hasPrefix } ?: WITH_PREFIX_FORMAT.format(baseURL)
-        val url = urlWithPrefix.trimStart().trimEnd { it == '/' || it.isWhitespace() }
+        val url = urlWithPrefix.trimEnd { it == '/' }
 
-        logger.d { "checkBaseURL: Created URL = $url, with prefix = $urlWithPrefix" }
+        logger.d { "checkBaseURL: Created URL = \"$url\", with prefix = \"$urlWithPrefix\"" }
         if (url == serverInfoRepo.getUrl()) {
             logger.d { "checkBaseURL: new URL matches current" }
             _uiState.value = OperationUiState.fromResult(Result.success(Unit))

--- a/app/src/test/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModelTest.kt
+++ b/app/src/test/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModelTest.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.test.*
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
-import java.net.UnknownHostException
 import javax.net.ssl.SSLHandshakeException
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -126,7 +125,7 @@ class BaseURLViewModelTest : BaseUnitTest() {
     @Test
     fun `when saving base url with no prefix and https throws non ssl expect no http`() = runTest {
         coEvery { serverInfoRepo.getUrl() } returns null
-        val err = NetworkError.MalformedUrl(UnknownHostException())
+        val err = NetworkError.NotMealie(IOException())
         coEvery { serverInfoRepo.tryBaseURL("https://test") } returns Result.failure(err)
         subject.saveBaseUrl("test")
         coVerify(inverse = true) { serverInfoRepo.tryBaseURL("http://test") }

--- a/app/src/test/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModelTest.kt
+++ b/app/src/test/java/gq/kirmanak/mealient/ui/baseurl/BaseURLViewModelTest.kt
@@ -4,17 +4,21 @@ import com.google.common.truth.Truth.assertThat
 import gq.kirmanak.mealient.data.auth.AuthRepo
 import gq.kirmanak.mealient.data.baseurl.ServerInfoRepo
 import gq.kirmanak.mealient.data.recipes.RecipeRepo
+import gq.kirmanak.mealient.datasource.NetworkError
 import gq.kirmanak.mealient.test.AuthImplTestData.TEST_BASE_URL
 import gq.kirmanak.mealient.test.BaseUnitTest
 import gq.kirmanak.mealient.ui.OperationUiState
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.*
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
+import java.net.UnknownHostException
+import javax.net.ssl.SSLHandshakeException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BaseURLViewModelTest : BaseUnitTest() {
@@ -104,5 +108,36 @@ class BaseURLViewModelTest : BaseUnitTest() {
         subject.saveBaseUrl(TEST_BASE_URL)
         advanceUntilIdle()
         assertThat(subject.uiState.value).isInstanceOf(OperationUiState.Failure::class.java)
+    }
+
+    @Test
+    fun `when saving base url with no prefix and https throws expect http attempt`() = runTest {
+        coEvery { serverInfoRepo.getUrl() } returns null
+        val err = NetworkError.MalformedUrl(SSLHandshakeException("test"))
+        coEvery { serverInfoRepo.tryBaseURL("https://test") } returns Result.failure(err)
+        coEvery { serverInfoRepo.tryBaseURL("http://test") } returns Result.success(Unit)
+        subject.saveBaseUrl("test")
+        coVerifyOrder {
+            serverInfoRepo.tryBaseURL("https://test")
+            serverInfoRepo.tryBaseURL("http://test")
+        }
+    }
+
+    @Test
+    fun `when saving base url with no prefix and https throws non ssl expect no http`() = runTest {
+        coEvery { serverInfoRepo.getUrl() } returns null
+        val err = NetworkError.MalformedUrl(UnknownHostException())
+        coEvery { serverInfoRepo.tryBaseURL("https://test") } returns Result.failure(err)
+        subject.saveBaseUrl("test")
+        coVerify(inverse = true) { serverInfoRepo.tryBaseURL("http://test") }
+    }
+
+    @Test
+    fun `when saving base url with https prefix and https throws expect no http call`() = runTest {
+        coEvery { serverInfoRepo.getUrl() } returns null
+        val err = NetworkError.MalformedUrl(SSLHandshakeException("test"))
+        coEvery { serverInfoRepo.tryBaseURL("https://test") } returns Result.failure(err)
+        subject.saveBaseUrl("https://test")
+        coVerify(inverse = true) { serverInfoRepo.tryBaseURL("http://test") }
     }
 }

--- a/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/NetworkError.kt
+++ b/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/NetworkError.kt
@@ -1,6 +1,6 @@
 package gq.kirmanak.mealient.datasource
 
-sealed class NetworkError(cause: Throwable) : RuntimeException(cause) {
+sealed class NetworkError(cause: Throwable) : RuntimeException(cause.message, cause) {
     class Unauthorized(cause: Throwable) : NetworkError(cause)
     class NoServerConnection(cause: Throwable) : NetworkError(cause)
     class NotMealie(cause: Throwable) : NetworkError(cause)

--- a/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/BaseUrlInterceptor.kt
+++ b/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/BaseUrlInterceptor.kt
@@ -4,7 +4,7 @@ import gq.kirmanak.mealient.datasource.LocalInterceptor
 import gq.kirmanak.mealient.datasource.ServerUrlProvider
 import gq.kirmanak.mealient.logging.Logger
 import kotlinx.coroutines.runBlocking
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
@@ -37,6 +37,7 @@ class BaseUrlInterceptor @Inject constructor(
     }
 
     private fun getBaseUrl() = runBlocking {
-        serverUrlProvider.getUrl()?.toHttpUrlOrNull() ?: throw IOException("Base URL is unknown")
+        val url = serverUrlProvider.getUrl() ?: throw IOException("Base URL is unknown")
+        url.runCatching { toHttpUrl() }.recover { throw IOException(it) }.getOrThrow()
     }
 }

--- a/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/BaseUrlInterceptor.kt
+++ b/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/BaseUrlInterceptor.kt
@@ -38,6 +38,6 @@ class BaseUrlInterceptor @Inject constructor(
 
     private fun getBaseUrl() = runBlocking {
         val url = serverUrlProvider.getUrl() ?: throw IOException("Base URL is unknown")
-        url.runCatching { toHttpUrl() }.recover { throw IOException(it) }.getOrThrow()
+        url.runCatching { toHttpUrl() }.recover { throw IOException(it.message, it) }.getOrThrow()
     }
 }

--- a/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/BaseUrlInterceptor.kt
+++ b/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/BaseUrlInterceptor.kt
@@ -38,6 +38,11 @@ class BaseUrlInterceptor @Inject constructor(
 
     private fun getBaseUrl() = runBlocking {
         val url = serverUrlProvider.getUrl() ?: throw IOException("Base URL is unknown")
-        url.runCatching { toHttpUrl() }.recover { throw IOException(it.message, it) }.getOrThrow()
+        url.runCatching {
+            toHttpUrl()
+        }.fold(
+            onSuccess = { it },
+            onFailure = { throw IOException(it.message, it) },
+        )
     }
 }


### PR DESCRIPTION
Fixes the issue described in #123. When the user doesn't provide any base URL scheme and automatically chosen HTTPS fails then in some cases it makes sense to try HTTP which might succeed. 