### PR TITLE
Handle new session in log file appender

### DIFF
--- a/logging/src/main/kotlin/gq/kirmanak/mealient/logging/FileAppender.kt
+++ b/logging/src/main/kotlin/gq/kirmanak/mealient/logging/FileAppender.kt
@@ -13,7 +13,6 @@ import java.io.FileWriter
 import java.io.IOException
 import java.io.Writer
 import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -42,9 +41,6 @@ internal class FileAppender @Inject constructor(
 
     private val coroutineScope = CoroutineScope(dispatchers.io + SupervisorJob())
 
-    private val dateTimeFormatter =
-        DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.systemDefault())
-
     init {
         startLogWriter()
     }
@@ -70,8 +66,10 @@ internal class FileAppender @Inject constructor(
         }
 
         coroutineScope.launch {
+            fileWriter.appendLine("Session started at ${Instant.now().formatted()}")
+
             for (logInfo in logChannel) {
-                val time = dateTimeFormatter.format(logInfo.logTime)
+                val time = logInfo.logTime.formatted()
                 val level = logInfo.logLevel.name.first()
                 logInfo.message.lines().forEach {
                     try {
@@ -83,6 +81,8 @@ internal class FileAppender @Inject constructor(
             }
         }
     }
+
+    private fun Instant.formatted(): String = DateTimeFormatter.ISO_INSTANT.format(this)
 
     override fun isLoggable(logLevel: LogLevel): Boolean = true
 

--- a/logging/src/main/kotlin/gq/kirmanak/mealient/logging/FileAppender.kt
+++ b/logging/src/main/kotlin/gq/kirmanak/mealient/logging/FileAppender.kt
@@ -1,6 +1,9 @@
 package gq.kirmanak.mealient.logging
 
+import android.app.Activity
 import android.app.Application
+import android.app.Application.ActivityLifecycleCallbacks
+import android.os.Bundle
 import gq.kirmanak.mealient.architecture.configuration.AppDispatchers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -43,6 +46,22 @@ internal class FileAppender @Inject constructor(
 
     init {
         startLogWriter()
+        startLifecycleObserver()
+    }
+
+    private fun startLifecycleObserver() {
+        val observer = object : DefaultActivityLifecycleCallbacks() {
+            override fun onActivityPaused(activity: Activity) {
+                super.onActivityPaused(activity)
+                try {
+                    fileWriter?.flush()
+                } catch (e: IOException) {
+                    // Ignore
+                }
+            }
+        }
+
+        application.registerActivityLifecycleCallbacks(observer)
     }
 
     private fun createFileWriter(): Writer? {
@@ -106,4 +125,22 @@ internal class FileAppender @Inject constructor(
             // Ignore
         }
     }
+}
+
+private open class DefaultActivityLifecycleCallbacks : ActivityLifecycleCallbacks {
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+    override fun onActivityStarted(activity: Activity) = Unit
+
+    override fun onActivityResumed(activity: Activity) = Unit
+
+    override fun onActivityPaused(activity: Activity) = Unit
+
+    override fun onActivityStopped(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) = Unit
+
 }


### PR DESCRIPTION
This PR fixes three issues that appear when new session starts:

1. The last lines of the previous session are not written to the file because they were buffered by the writer whose buffer was not filled.
2. Hard to distinguish when new session starts as there are no marks.
3. Preferences storage might log base URL before the base URL redactor is initialized.