### PR TITLE
 Mealie v2.0.0 Shopping List API Not Working with Mealient #335 

### DIFF
--- a/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/MealieServiceKtor.kt
+++ b/datasource/src/main/kotlin/gq/kirmanak/mealient/datasource/impl/MealieServiceKtor.kt
@@ -140,7 +140,7 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun getShoppingLists(page: Int, perPage: Int): GetShoppingListsResponse {
         return httpClient.get {
-            endpoint("/api/groups/shopping/lists") {
+            endpoint("/api/households/shopping/lists") {
                 parameters.append("page", page.toString())
                 parameters.append("perPage", perPage.toString())
             }
@@ -149,19 +149,19 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun getShoppingList(id: String): GetShoppingListResponse {
         return httpClient.get {
-            endpoint("/api/groups/shopping/lists/$id")
+            endpoint("/api/households/shopping/lists/$id")
         }.body()
     }
 
     override suspend fun getShoppingListItem(id: String): JsonElement {
         return httpClient.get {
-            endpoint("/api/groups/shopping/items/$id")
+            endpoint("/api/households/shopping/items/$id")
         }.body()
     }
 
     override suspend fun updateShoppingListItem(id: String, request: JsonElement) {
         httpClient.put {
-            endpoint("/api/groups/shopping/items/$id")
+            endpoint("/api/households/shopping/items/$id")
             contentType(ContentType.Application.Json)
             setBody(request)
         }
@@ -169,7 +169,7 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun deleteShoppingListItem(id: String) {
         httpClient.delete {
-            endpoint("/api/groups/shopping/items/$id")
+            endpoint("/api/households/shopping/items/$id")
         }
     }
 
@@ -191,7 +191,7 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun createShoppingListItem(request: CreateShoppingListItemRequest) {
         httpClient.post {
-            endpoint("/api/groups/shopping/items")
+            endpoint("/api/households/shopping/items")
             contentType(ContentType.Application.Json)
             setBody(request)
         }
@@ -199,7 +199,7 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun createShoppingList(request: CreateShoppingListRequest) {
         httpClient.post {
-            endpoint("/api/groups/shopping/lists")
+            endpoint("/api/households/shopping/lists")
             contentType(ContentType.Application.Json)
             setBody(request)
         }
@@ -207,13 +207,13 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun deleteShoppingList(id: String) {
         httpClient.delete {
-            endpoint("/api/groups/shopping/lists/$id")
+            endpoint("/api/households/shopping/lists/$id")
         }
     }
 
     override suspend fun updateShoppingList(id: String, request: JsonElement) {
         httpClient.put {
-            endpoint("/api/groups/shopping/lists/$id")
+            endpoint("/api/households/shopping/lists/$id")
             contentType(ContentType.Application.Json)
             setBody(request)
         }
@@ -221,7 +221,7 @@ internal class MealieServiceKtor @Inject constructor(
 
     override suspend fun getShoppingListJson(id: String): JsonElement {
         return httpClient.get {
-            endpoint("/api/groups/shopping/lists/$id")
+            endpoint("/api/households/shopping/lists/$id")
         }.body()
     }
 


### PR DESCRIPTION
The endpoints for interacting with shopping lists have changed in Mealie. This may cause issues for users who have integrated with the Mealie API, particularly those using the shopping list functionality.

Previous Endpoints: 
    Example of an old endpoint: `/api/groups/shopping/lists`
New Endpoints:
    Example of an new endpoint: `/api/households/shopping/lists`
